### PR TITLE
Wait for dismissable instructions to be dismissed, before moving on

### DIFF
--- a/src/commands/briefcaseCommand.ts
+++ b/src/commands/briefcaseCommand.ts
@@ -34,7 +34,7 @@ export class BriefcaseCommand {
             }
         );
 
-        InstructionsWebviewProvider.showDismissableInstructions(
+        await InstructionsWebviewProvider.showDismissableInstructions(
             extensionUri,
             l10n.t('Briefcase Setup Instruction'),
             'src/instructions/briefcase.html'

--- a/src/commands/templateChooserCommand.ts
+++ b/src/commands/templateChooserCommand.ts
@@ -83,7 +83,7 @@ export class TemplateChooserCommand {
             TemplateChooserCommand.TEMPLATE_LIST_ITEMS[0].filenamePrefix
         );
 
-        InstructionsWebviewProvider.showDismissableInstructions(
+        await InstructionsWebviewProvider.showDismissableInstructions(
             extensionUri,
             l10n.t('Landing Page Customization'),
             'src/instructions/landingpage.html'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,17 +37,14 @@ export function activate(context: vscode.ExtensionContext) {
         wizardCommand,
         async (fromPostProjectCreation: boolean = false) => {
             if (fromPostProjectCreation) {
-                await AuthorizeCommand.authorizeToOrg().then(async () => {
-                    await BriefcaseCommand.setupBriefcase(context.extensionUri);
-                });
-
+                await AuthorizeCommand.authorizeToOrg();
+                await BriefcaseCommand.setupBriefcase(context.extensionUri);
                 await TemplateChooserCommand.copyDefaultTemplate(
                     context.extensionUri
                 );
 
-                await AuthorizeCommand.authorizeToOrg().then(async () => {
-                    await DeployToOrgCommand.deployToOrg();
-                });
+                await AuthorizeCommand.authorizeToOrg();
+                await DeployToOrgCommand.deployToOrg();
 
                 InstructionsWebviewProvider.showDismissableInstructions(
                     context.extensionUri,

--- a/src/webviews.ts
+++ b/src/webviews.ts
@@ -72,21 +72,24 @@ export class InstructionsWebviewProvider {
         panel.webview.html = webviewContent;
     }
 
-    public static showDismissableInstructions(
+    public static async showDismissableInstructions(
         extensionUri: vscode.Uri,
         title: string,
         contentPath: string
-    ) {
-        const provider: InstructionsWebviewProvider =
-            new InstructionsWebviewProvider(extensionUri);
-        provider.showInstructionWebview(title, contentPath, [
-            {
-                buttonId: 'okButton',
-                action: (panel) => {
-                    panel.dispose();
+    ): Promise<void> {
+        return new Promise((resolve) => {
+            const provider: InstructionsWebviewProvider =
+                new InstructionsWebviewProvider(extensionUri);
+            provider.showInstructionWebview(title, contentPath, [
+                {
+                    buttonId: 'okButton',
+                    action: (panel) => {
+                        panel.dispose();
+                        return resolve();
+                    }
                 }
-            }
-        ]);
+            ]);
+        });
     }
 
     /**


### PR DESCRIPTION
~~Initially opening this as a draft because I don't know whether or not we want to change the behavior.~~ But per previous discussions, this would Promise-ify `InstructionsWebviewProvider.showDismissableInstructions()`, so that you could wait until the user had dismissed the instructions view, before moving on to the next stage.